### PR TITLE
Add trailing slash

### DIFF
--- a/xcode-plugin-updater.sh
+++ b/xcode-plugin-updater.sh
@@ -130,7 +130,7 @@ function updatePlugins
 		# Done
 		echo "${GREEN}✓ [$(basename "${plugin}")]${COLOREND} Plugin updated successfully."
 
-	done < <(find "${P_PLUGIN_DIR}" -maxdepth 1 -name "*.xcplugin" -print0)
+	done < <(find "${P_PLUGIN_DIR}/" -maxdepth 1 -name "*.xcplugin" -print0)
 }
 
 # --------------------------------


### PR DESCRIPTION
Hi there,

Nice little script. I found that I had to add a trailing slash for the `find` operation to succeed, though...

I should point out that my plugins found is actually a symlink into a DropBox folder, so perhaps that's why.
